### PR TITLE
reduces healthcheck interval for faster healthy state

### DIFF
--- a/5.7/Dockerfile.in
+++ b/5.7/Dockerfile.in
@@ -25,4 +25,4 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 EXPOSE 3306 33060
 CMD ["mysqld"]
-HEALTHCHECK CMD ["/healthcheck.sh"]
+HEALTHCHECK --interval=5s --retries=5 CMD ["/healthcheck.sh"]


### PR DESCRIPTION
## The Problem:

## The Fix:
This reduces the healthcheck interval so that readiness is checked sooner and more rapidly, allowing the container to report as healthy faster.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

