### PR TITLE
Update self-naming for new github repo docker.mysql-local and drud/mysql-local

### DIFF
--- a/5.7/Makefile
+++ b/5.7/Makefile
@@ -6,7 +6,7 @@
 # PKG := github.com/drud/repo_name
 
 # Docker repo for a push
-DOCKER_REPO ?= drud/mysql-docker-local-57
+DOCKER_REPO ?= drud/mysql-local-57
 
 # Upstream repo used in the Dockerfile
 UPSTREAM_REPO ?= oraclelinux:7.3

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 TAG = $(shell git rev-parse --abbrev-ref HEAD | tr -d '\n')
-PREFIX = drud/mysql-docker-local
+PREFIX = drud/mysql-local
 DIRECTORY = $(shell pwd)
 
 

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ version: 2
 executorType: machine
 stages:
   build:
-    workDir: ~/mysql-docker-local
+    workDir: ~/docker.mysql-local
     steps:
       - type: checkout
       - type: shell


### PR DESCRIPTION
## The Problem:

OP: https://github.com/drud/ddev/issues/334 renaming the repository to docker.mysql-local

## The Fix:

Simple renaming.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

