### PR TITLE
Write MySQL data using the DDEV_GID and DDEV_UID user IDs

### DIFF
--- a/5.7/Dockerfile.in
+++ b/5.7/Dockerfile.in
@@ -20,7 +20,6 @@ RUN rpmkeys --import http://repo.mysql.com/RPM-GPG-KEY-mysql \
 RUN mkdir /docker-entrypoint-initdb.data
 ADD files /
 RUN chmod ugo+x /import.sh /healthcheck.sh
-VOLUME /var/lib/mysql
 ENTRYPOINT ["/entrypoint.sh"]
 
 EXPOSE 3306 33060

--- a/5.7/files/entrypoint.sh
+++ b/5.7/files/entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -e
 
+# Change  to UID/GID of the docker user
+if [ -n "$DDEV_UID" ] ; then
+	echo "changing mysql user to uid: $DDEV_UID"
+	usermod -u $DDEV_UID mysql
+fi
+if [ -n "$DDEV_GID" ] ; then
+	echo "changing mysql group to uid: $DDEV_GID"
+	groupmod -g $DDEV_GID mysql
+fi
+
 # set configuration values based on environment
 if grep -q max_allowed_packet /etc/my.cnf
 then
@@ -116,6 +126,8 @@ if [ "$1" = 'mysqld' ]; then
 	# This .my.cnf configuration prevents the initialization process from
 	# succeeding, so it is moved into place after initialization is complete.
 	cp /root/mysqlclient.cnf /root/.my.cnf
+
+
 fi
 
 


### PR DESCRIPTION
## The Problem:
With the introduction of drud/ddev#337 we need to ensure that files written to the host mounted data directory are writeable by the user running docker.

## The Fix:
This PR introduces a $DDEV_UID/$DDEV_GID parameter to the startup script. When these environment variables are present, the MySQL user will be switched to use that ID. This allows the user running docker to maintain control of files which are written to the data directory, and helps avoid messy cleanup scenarios.



## Related Issue Link(s):

## Release/Deployment notes:
- [ ] Roll a new release of this container
- [ ] Update drud/ddev#337 to use the new version of this container.
