### PR TITLE
Make mysql-local-57 work with Windows... and other ways, improves #25

### DIFF
--- a/5.7/files/entrypoint.sh
+++ b/5.7/files/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+# set -x
 
 # Change  to UID/GID of the docker user
 if [ -n "$DDEV_UID" ] ; then
@@ -13,120 +13,97 @@ fi
 chown -R mysql:mysql /var/lib/mysql
 chown mysql:mysql /var/log/mysqld.log
 
-# set configuration values based on environment
-if grep -q max_allowed_packet /etc/my.cnf
-then
-	sed -i 's/\(max_allowed_packet\).*/\1 = '$MYSQL_MAX_ALLOWED_PACKET'/' /etc/my.cnf
-else
-	echo "max_allowed_packet=$MYSQL_MAX_ALLOWED_PACKET" >> /etc/my.cnf
-fi
+# If no mysql database exists in /var/lib/mysql, run initialization
+if [ ! -d "/var/lib/mysql/mysql" ]; then
+	if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
+		echo 'error: database is uninitialized and password option is not specified '
+		echo '  You need to specify one of MYSQL_ROOT_PASSWORD, MYSQL_ALLOW_EMPTY_PASSWORD and MYSQL_RANDOM_ROOT_PASSWORD'
+		exit 1
+	fi
 
-# if command starts with an option, prepend mysqld
-if [ "${1:0:1}" = '-' ]; then
-	set -- mysqld "$@"
-fi
+	echo 'Initializing database'
+	if ! mysqld --initialize-insecure=on; then
+		echo "Failed to initialize empty database, contents of mysqld.log follow"
+		cat /var/log/mysqld.log
+		exit 3
+	fi
 
-if [ "$1" = 'mysqld' ]; then
-	# Get config
-	DATADIR="$("$@" --verbose --help --log-bin-index=/tmp/tmp.index 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
+	echo 'Database initialized'
 
-	if [ ! -d "$DATADIR/mysql" ]; then
-		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
-			echo 'error: database is uninitialized and password option is not specified '
-			echo '  You need to specify one of MYSQL_ROOT_PASSWORD, MYSQL_ALLOW_EMPTY_PASSWORD and MYSQL_RANDOM_ROOT_PASSWORD'
-			exit 1
+	mysqld --skip-networking &
+	pid="$!"
+
+	mysql=( mysql --protocol=socket --socket=/var/tmp/mysql.sock -uroot )
+
+	for i in {30..0}; do
+		if mysql -e "SELECT 1" &> /dev/null; then
+			break
 		fi
-		# If the password variable is a filename we use the contents of the file
-		if [ -f "$MYSQL_ROOT_PASSWORD" ]; then
-			MYSQL_ROOT_PASSWORD="$(cat $MYSQL_ROOT_PASSWORD)"
-		fi
+		echo 'MySQL init process in progress...'
+		sleep 1
+	done
+	if [ "$i" = 0 ]; then
+		echo 'MySQL init process failed.'
+		exit 1
+	fi
 
-		echo 'Initializing database'
-		$"$@" --initialize-insecure=on
-		echo 'Database initialized'
+	mysql_tzinfo_to_sql /usr/share/zoneinfo | "${mysql[@]}" mysql
 
-		"$@" --skip-networking &
-		pid="$!"
+	"${mysql[@]}" <<-EOSQL
+		-- What's done in this file shouldn't be replicated
+		--  or products like mysql-fabric won't work
+		SET @@SESSION.SQL_LOG_BIN=0;
+		DELETE FROM mysql.user WHERE user NOT IN ('mysql.sys', 'mysqlxsys');
+		CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
+		GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
+		DROP DATABASE IF EXISTS test ;
+		FLUSH PRIVILEGES ;
+	EOSQL
+	if [ ! -z "$MYSQL_ROOT_PASSWORD" ]; then
+		mysql+=( -p"${MYSQL_ROOT_PASSWORD}" )
+	fi
 
-		mysql=( mysql --protocol=socket -uroot )
+	if [ "$MYSQL_DATABASE" ]; then
+		echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" | "${mysql[@]}"
+		mysql+=( "$MYSQL_DATABASE" )
+	fi
 
-		for i in {30..0}; do
-			if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then
-				break
-			fi
-			echo 'MySQL init process in progress...'
-			sleep 1
-		done
-		if [ "$i" = 0 ]; then
-			echo 'MySQL init process failed.'
-			exit 1
-		fi
-
-		mysql_tzinfo_to_sql /usr/share/zoneinfo | "${mysql[@]}" mysql
-
-		if [ ! -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
-			MYSQL_ROOT_PASSWORD="$(pwmake 128)"
-			echo "GENERATED ROOT PASSWORD: $MYSQL_ROOT_PASSWORD"
-		fi
-		"${mysql[@]}" <<-EOSQL
-			-- What's done in this file shouldn't be replicated
-			--  or products like mysql-fabric won't work
-			SET @@SESSION.SQL_LOG_BIN=0;
-			DELETE FROM mysql.user WHERE user NOT IN ('mysql.sys', 'mysqlxsys');
-			CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
-			GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
-			DROP DATABASE IF EXISTS test ;
-			FLUSH PRIVILEGES ;
-		EOSQL
-		if [ ! -z "$MYSQL_ROOT_PASSWORD" ]; then
-			mysql+=( -p"${MYSQL_ROOT_PASSWORD}" )
-		fi
+	if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
+		echo "Creating mysql user $MYSQL_USER"
+		echo "CREATE USER '"$MYSQL_USER"'@'%' IDENTIFIED BY '"$MYSQL_PASSWORD"' ;" | "${mysql[@]}"
 
 		if [ "$MYSQL_DATABASE" ]; then
-			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" | "${mysql[@]}"
-			mysql+=( "$MYSQL_DATABASE" )
+			echo "GRANT ALL ON \`"$MYSQL_DATABASE"\`.* TO '"$MYSQL_USER"'@'%' ;" | "${mysql[@]}"
 		fi
 
-		if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
-			echo "CREATE USER '"$MYSQL_USER"'@'%' IDENTIFIED BY '"$MYSQL_PASSWORD"' ;" | "${mysql[@]}"
-
-			if [ "$MYSQL_DATABASE" ]; then
-				echo "GRANT ALL ON \`"$MYSQL_DATABASE"\`.* TO '"$MYSQL_USER"'@'%' ;" | "${mysql[@]}"
-			fi
-
-			echo 'FLUSH PRIVILEGES ;' | "${mysql[@]}"
-		fi
-		echo
-		for f in /docker-entrypoint-initdb.d/*; do
-			case "$f" in
-				*.sh)  echo "$0: running $f"; . "$f" ;;
-				*.sql) echo "$0: running $f"; "${mysql[@]}" < "$f" && echo ;;
-				*)     echo "$0: ignoring $f" ;;
-			esac
-			echo
-		done
-
-		if [ ! -z "$MYSQL_ONETIME_PASSWORD" ]; then
-			"${mysql[@]}" <<-EOSQL
-				ALTER USER 'root'@'%' PASSWORD EXPIRE;
-			EOSQL
-		fi
-
-		if ! kill -s TERM "$pid" || ! wait "$pid"; then
-			echo >&2 'MySQL init process failed.'
-			exit 1
-		fi
-
+		echo 'FLUSH PRIVILEGES ;' | "${mysql[@]}"
 	fi
 	echo
-	echo 'MySQL init process done. Ready for start up.'
-	echo
+	for f in /docker-entrypoint-initdb.d/*; do
+		case "$f" in
+			*.sh)  echo "$0: running $f"; . "$f" ;;
+			*.sql) echo "$0: running $f"; "${mysql[@]}" < "$f" && echo ;;
+			*)     echo "$0: ignoring $f" ;;
+		esac
+		echo
+	done
 
-	# This .my.cnf configuration prevents the initialization process from
-	# succeeding, so it is moved into place after initialization is complete.
-	cp /root/mysqlclient.cnf /root/.my.cnf
+	if ! kill -s TERM "$pid" || ! wait "$pid"; then
+		echo >&2 'MySQL init process failed.'
+		exit 4
+	fi
 
 fi
+echo
+echo 'MySQL init process done. Ready for start up.'
+echo
 
+# This .my.cnf configuration prevents the initialization process from
+# succeeding, so it is moved into place after initialization is complete.
+cp /root/mysqlclient.cnf /root/.my.cnf
 
-exec "$@"
+if ! mysqld --max-allowed-packet=${MYSQL_MAX_ALLOWED_PACKET:-16m} ; then
+ 	echo "Launch of $@ failed with result $?, mysqld.log follows"
+ 	cat /var/log/mysqld.log
+ 	exit 5
+fi

--- a/5.7/files/entrypoint.sh
+++ b/5.7/files/entrypoint.sh
@@ -102,8 +102,4 @@ echo
 # succeeding, so it is moved into place after initialization is complete.
 cp /root/mysqlclient.cnf /root/.my.cnf
 
-if ! mysqld --max-allowed-packet=${MYSQL_MAX_ALLOWED_PACKET:-16m} ; then
- 	echo "Launch of $@ failed with result $?, mysqld.log follows"
- 	cat /var/log/mysqld.log
- 	exit 5
-fi
+exec mysqld --max-allowed-packet=${MYSQL_MAX_ALLOWED_PACKET:-16m}

--- a/5.7/files/etc/my.cnf
+++ b/5.7/files/etc/my.cnf
@@ -54,7 +54,8 @@ table-definition-cache         = 4096
 table-open-cache               = 4096
 
 # INNODB #
-innodb-flush-method            = O_DIRECT
+# Cannot use O_DIRECT with windows mounts!!!
+# innodb-flush-method            = O_DIRECT
 innodb-log-files-in-group      = 2
 innodb-log-file-size           = 64M
 innodb-flush-log-at-trx-commit = 2

--- a/5.7/files/etc/my.cnf
+++ b/5.7/files/etc/my.cnf
@@ -2,7 +2,7 @@
 
 # CLIENT #
 port                           = 3306
-socket                         = /var/lib/mysql/mysql.sock
+socket                         = /var/tmp/mysql.sock
 
 [mysqld]
 #
@@ -32,8 +32,8 @@ symbolic-links=0
 # GENERAL #
 user                           = mysql
 default-storage-engine         = InnoDB
-socket                         = /var/lib/mysql/mysql.sock
-pid-file                       = /var/lib/mysql/mysql.pid
+socket                         = /var/tmp/mysql.sock
+pid-file                       = /var/tmp/mysql.pid
 
 # MyISAM #
 key-buffer-size                = 64M


### PR DESCRIPTION
## The Problem:

There were a number of reasons drud/mysql-local-57 didn't work on windows, so I had to do development on it and fix it. In order to do that I tried to address #25.

## The Fix:

* Move the socket and pid files off of the mount (there's no reason for them to be there)
* Remove the setting of innodb-flush-method to O_DIRECT, which only works on Linux filesystems. **Note that this may have performance implications so this PR must be analyzed in terms of performance**
* Simplify the entrypoint.sh script. It now gives much more feedback when something is wrong and generally checks return values when launching things.

## The Test:

Run ddev on windows (post v0.8).

## Automation Overview:

## Related Issue Link(s):

* ddev broken on windows: https://github.com/drud/ddev/issues/384
* Simplify entrypoint script #25 

## Release/Deployment notes:

- [ ] Version bump required in ddev
