### PR TITLE
Use utf8mb4 charset for database

### DIFF
--- a/5.7/files/entrypoint.sh
+++ b/5.7/files/entrypoint.sh
@@ -64,7 +64,7 @@ if [ ! -d "/var/lib/mysql/mysql" ]; then
 	fi
 
 	if [ "$MYSQL_DATABASE" ]; then
-		echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" | "${mysql[@]}"
+		echo "CREATE DATABASE  IF NOT EXISTS \`$MYSQL_DATABASE\` character set UTF8mb4 collate utf8mb4_bin;" | "${mysql[@]}"
 		mysql+=( "$MYSQL_DATABASE" )
 	fi
 

--- a/5.7/files/entrypoint.sh
+++ b/5.7/files/entrypoint.sh
@@ -64,7 +64,7 @@ if [ ! -d "/var/lib/mysql/mysql" ]; then
 	fi
 
 	if [ "$MYSQL_DATABASE" ]; then
-		echo "CREATE DATABASE  IF NOT EXISTS \`$MYSQL_DATABASE\` character set UTF8mb4 collate utf8mb4_bin;" | "${mysql[@]}"
+		echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" | "${mysql[@]}"
 		mysql+=( "$MYSQL_DATABASE" )
 	fi
 

--- a/5.7/files/etc/my.cnf
+++ b/5.7/files/etc/my.cnf
@@ -61,6 +61,9 @@ innodb-log-file-size           = 64M
 innodb-flush-log-at-trx-commit = 2
 innodb-file-per-table          = 1
 innodb-buffer-pool-size        = 1024M
+innodb_large_prefix=true
+innodb_file_format=barracuda
+innodb_file_per_table=true
 
 # LOGGING #
 log-error                      = /var/log/mysqld.log

--- a/5.7/files/etc/my.cnf
+++ b/5.7/files/etc/my.cnf
@@ -25,6 +25,9 @@ skip-name-resolve
 datadir=/var/lib/mysql
 secure-file-priv=/var/lib/mysql-files
 
+character-set-server = utf8mb4
+collation-server = utf8mb4_bin
+
 # Disabling symbolic-links is recommended to prevent assorted security risks
 symbolic-links=0
 


### PR DESCRIPTION
## The Problem:

Typo3 requires a utf8 database. Drupal *wants* one, drupal wants utf8mb4 really to handle newer emojis and related character sets. We were using the default latin1. 

Related: https://github.com/drud/ddev/issues/500 (stand up typo3 instance)
Drupal 7.50+ and utf8mb4: https://www.drupal.org/node/2754539

## The Fix:

Change the database creation and collation to utf8mb4

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

Note that ddev must be updated to create settings/settings.local with values as shown in https://www.drupal.org/node/2754539 

This just adds:
```
  'charset' => 'utf8mb4',
  'collation' => 'utf8mb4_general_ci',
```