### PR TITLE
Make sure that /root/.my.cnf is always in place at end of startup

### DIFF
--- a/files/docker-entrypoint.sh
+++ b/files/docker-entrypoint.sh
@@ -67,10 +67,6 @@ if [ ! -d "/var/lib/mysql/mysql" ]; then
 		GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION;
 EOF
 
-	# mysqladmin --socket=$SOCKET  -uroot password "$MYSQL_ROOT_PASSWORD"
-
-	mv /root/mysqlclient.cnf /root/.my.cnf
-
 	if ! kill -s TERM "$pid" || ! wait "$pid"; then
 		echo >&2 'Mariadb initialization process failed.'
 		exit 1
@@ -79,11 +75,12 @@ EOF
 	echo 'Database initialized'
 fi
 
+
 echo
 echo 'MySQL init process done. Ready for start up.'
 echo
 
-
+cp /root/mysqlclient.cnf /root/.my.cnf
 chown -R mysql:mysql /var/lib/mysql /var/log/mysql*
 
 echo "Starting mysqld."


### PR DESCRIPTION
## The Problem:

There was an (easy) path to not getting the /root/.my.cnf in place on a container. Because the copy was keyed on whether the database existed, if you did `ddev rm` and then `ddev start` the logic creating the container didn't copy .my.cnf into place. So import-db didn't work because the default database wasn't selected. 

I'm suspicious of the import requiring a default db that comes from .my.cnf, but didn't fix that here.

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

